### PR TITLE
Update helpers.ps1

### DIFF
--- a/zoiper/tools/helpers.ps1
+++ b/zoiper/tools/helpers.ps1
@@ -59,7 +59,7 @@ function Update-RegistryValue {
     catch {
         New-ItemProperty `
             -Path $Path `
-            -Name $Name`
+            -Name $Name `
             -PropertyType $Type `
             -Value $Value
         Write-Output `


### PR DESCRIPTION
missing space breaks compatibility to powershell <=2.0 e.g. windows 7